### PR TITLE
feat #9 : Improved performance of T2B writing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,7 @@ name = "ievr_cfg_bin_editor_core"
 version = "0.1.0"
 dependencies = [
  "crc-fast",
+ "rustc-hash",
  "serde",
  "serde_json",
 ]
@@ -102,6 +103,12 @@ checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "serde"

--- a/ievr_cfg_bin_editor-cli/src/main.rs
+++ b/ievr_cfg_bin_editor-cli/src/main.rs
@@ -2,7 +2,7 @@ use std::{env, error::Error, fs::File, io::Write, path::PathBuf};
 
 use memmap2::Mmap;
 
-use ievr_cfg_bin_editor_core::{parse_database, test_t2b_writing};
+use ievr_cfg_bin_editor_core::parse_database;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let input_path = env::args()
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let output_path = PathBuf::from(format!("{input_file_name}.json"));
 
     let mut file = File::create(output_path).unwrap();
-    file.write_all(database.serialize().as_bytes())?;
+    file.write_all(database.serialize()?.as_bytes())?;
 
     Ok(())
 }

--- a/ievr_cfg_bin_editor-core/Cargo.toml
+++ b/ievr_cfg_bin_editor-core/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2024"
 
 [dependencies]
 crc-fast = { version = "1.10", default-features = false, features = ["std"] }
+rustc-hash = "2.1.1"
 serde = { version = "1", default-features = false, features = ["derive", "std"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }

--- a/ievr_cfg_bin_editor-core/src/common/binary_writer.rs
+++ b/ievr_cfg_bin_editor-core/src/common/binary_writer.rs
@@ -42,10 +42,6 @@ impl BinaryWriter {
         self.write_bytes(&data.to_le_bytes());
     }
 
-    pub fn write_u16(&mut self, data: u16) {
-        self.write_bytes(&data.to_le_bytes());
-    }
-
     pub fn write_i32(&mut self, data: i32) {
         self.write_bytes(&data.to_le_bytes());
     }

--- a/ievr_cfg_bin_editor-core/src/common/binary_writer.rs
+++ b/ievr_cfg_bin_editor-core/src/common/binary_writer.rs
@@ -5,6 +5,13 @@ pub struct BinaryWriter {
 }
 
 impl BinaryWriter {
+    pub fn new(file_size: usize) -> Self {
+        BinaryWriter { 
+            data: Vec::with_capacity(file_size), 
+            position: 0
+        }
+    }
+    
     pub fn set_position(&mut self, position: usize) {
         if position > self.data.len() {
             self.data.resize(position, 0);

--- a/ievr_cfg_bin_editor-core/src/database.rs
+++ b/ievr_cfg_bin_editor-core/src/database.rs
@@ -12,6 +12,7 @@ pub use utils::*;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Database {
     source: DatabaseSource,
+    original_size: usize,
     tables: Vec<Table>,
 }
 
@@ -75,7 +76,11 @@ impl From<Rdbn> for Database {
             }
         }).collect();
 
-        Database { source: DatabaseSource::RDBN, tables }
+        Database { 
+            original_size: rdbn.file_size,
+            source: DatabaseSource::RDBN, 
+            tables 
+        }
     }
 }
 
@@ -109,12 +114,12 @@ impl From<T2b> for Database {
 
             let mut rows = Vec::with_capacity(table.len());
             for entry in table {
-                let values = entry.values.iter().map(|value | {
-                    vec![Value::from(value)]
+                let values = entry.values.into_iter().map(|value | {
+                    vec![value.into()]
                 }).collect();
 
                 rows.push(Row { 
-                    name: entry.name.clone(),
+                    name: entry.name,
                     values 
                 });
             }
@@ -126,7 +131,11 @@ impl From<T2b> for Database {
             }
         }).collect();
 
-        Database { source: DatabaseSource::T2B(t2b.encoding, t2b.value_length, t2b.hash_type), tables }
+        Database { 
+            original_size: t2b.file_size,
+            source: DatabaseSource::T2B(t2b.encoding, t2b.value_length, t2b.hash_type), 
+            tables 
+        }
     }
 }
 
@@ -139,8 +148,9 @@ impl Into<T2b> for Database {
                 for row in table.rows {
                     let entry = T2bEntry {
                         name: row.name,
-                        values: row.values.into_iter().flat_map(|vector| {
-                            vector.into_iter().map(Value::into)
+                        values: row.values.into_iter().map(|mut vector| {
+                            // We know T2Bs cannot hold more than 1 item per row
+                            vector.pop().unwrap().into()
                         }).collect()
                     };
 
@@ -149,6 +159,7 @@ impl Into<T2b> for Database {
             }
 
             T2b {
+                file_size: self.original_size,
                 entries,
                 encoding,
                 value_length,

--- a/ievr_cfg_bin_editor-core/src/database.rs
+++ b/ievr_cfg_bin_editor-core/src/database.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code)]
 
+use std::{fs::File, path::Path};
+
 use crate::{rdbn::Rdbn, t2b::{HashType, T2b, T2bEntry, ValueLength}};
 
 mod utils;
@@ -14,9 +16,8 @@ pub struct Database {
 }
 
 impl Database {
-    pub fn serialize(&self) -> String {
-        let json = serde_json::to_string_pretty(&self).unwrap();
-        json
+    pub fn serialize(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(&self)
     }
 
     pub fn tables(&self) -> &Vec<Table> {
@@ -29,6 +30,22 @@ impl Database {
 
     pub fn table_mut(&mut self, name: &str) -> Option<&mut Table> {
         self.tables.iter_mut().find(|table| table.name == name)
+    }
+
+    pub fn write<T: AsRef<Path>>(self, output_path: T) -> Result<(), std::io::Error> {
+        let mut output_file = File::create(output_path)?;
+
+        match self.source {
+            DatabaseSource::T2B(..) => {
+                let t2b: T2b = self.into();
+                t2b.write(&mut output_file)
+            }
+
+            DatabaseSource::RDBN => {
+                eprintln!("This tool doesn't support writing RDBN files as of now");
+                Err(std::io::ErrorKind::NotFound.into())
+            }
+        }
     }
 }
 
@@ -119,8 +136,6 @@ impl Into<T2b> for Database {
             let mut entries: Vec<T2bEntry> = Vec::with_capacity(self.tables.iter().map(|t| t.rows.len()).sum());
 
             for table in self.tables {
-                let len = table.rows.len() as i32; // The first row contains the number of entries
-
                 for row in table.rows {
                     let entry = T2bEntry {
                         name: row.name,

--- a/ievr_cfg_bin_editor-core/src/database/utils.rs
+++ b/ievr_cfg_bin_editor-core/src/database/utils.rs
@@ -98,8 +98,8 @@ impl From<&RdbnValue> for Value {
     }
 }
 
-impl From<&T2bEntryValue> for Value {
-    fn from(entry: &T2bEntryValue) -> Self {
+impl From<T2bEntryValue> for Value {
+    fn from(entry: T2bEntryValue) -> Self {
         match &entry.value {
             T2bValue::String(v) => Value::String(v.clone()),
             T2bValue::Integer(v) => Value::Int(*v),

--- a/ievr_cfg_bin_editor-core/src/lib.rs
+++ b/ievr_cfg_bin_editor-core/src/lib.rs
@@ -37,8 +37,6 @@ pub fn test_t2b_writing(file: &[u8]) {
 
         row.values[1][0] = Value::Float(1.1);
 
-        let new_t2b: T2b = database.into();
-
-        T2b::write(new_t2b);
+        database.write("output").unwrap();
     }
 }

--- a/ievr_cfg_bin_editor-core/src/rdbn.rs
+++ b/ievr_cfg_bin_editor-core/src/rdbn.rs
@@ -29,6 +29,7 @@ const MINIMUM_SIZE: usize = 0x3C;
 const RDBN_HEADER: u32 = const { u32::from_le_bytes(*b"RDBN") };
 
 pub struct Rdbn {
+    pub file_size: usize,
     pub types: Vec<RdbnTypeDeclaration>,
     pub lists: Vec<RdbnListEntry>,
 }
@@ -70,7 +71,7 @@ impl Rdbn {
 
         if let Some(string_lookup) = Self::read_strings(&mut binary_reader, header.hash_count, hash_offset, offset_offset, string_offset) {
             let value_offset = ((header.value_offset as i32) << 2) + data_offset as i32;
-            return Some(Self::create_rdbn(binary_reader, value_offset, string_offset, root_entries, type_entries, field_entries, string_lookup))
+            return Some(Self::create_rdbn(binary_reader, value_offset, string_offset, root_entries, type_entries, field_entries, string_lookup, file.len()))
         } else {
             None
         }
@@ -164,7 +165,10 @@ impl Rdbn {
         String::from_utf8(result).unwrap()
     }
 
-    fn create_rdbn(mut binary_reader: BinaryReader, value_offset: i32, string_offset: i32, root_entries: Vec<RdbnRootEntry>, type_entries: Vec<RdbnTypeEntry>, field_entries: Vec<RdbnFieldEntry>, string_lookup: HashMap<u32, String>) -> Rdbn {
+    fn create_rdbn(mut binary_reader: BinaryReader, value_offset: i32, string_offset: i32, root_entries: Vec<RdbnRootEntry>, 
+        type_entries: Vec<RdbnTypeEntry>, field_entries: Vec<RdbnFieldEntry>, string_lookup: HashMap<u32, String>,
+        file_size: usize
+    ) -> Rdbn {
         let mut type_declarations = Vec::with_capacity(type_entries.len());
         for type_entry in &type_entries {
             debug_assert!(type_entry.field_count > 0);
@@ -281,6 +285,7 @@ impl Rdbn {
         }
 
         return Rdbn {
+            file_size,
             types: distinct_types,
             lists,
         }

--- a/ievr_cfg_bin_editor-core/src/t2b.rs
+++ b/ievr_cfg_bin_editor-core/src/t2b.rs
@@ -13,6 +13,7 @@ mod writer;
 
 #[derive(Debug, Clone)]
 pub struct T2b {
+    pub file_size: usize,
     pub entries: Vec<T2bEntry>,
     pub encoding: i16,
     pub value_length: ValueLength,

--- a/ievr_cfg_bin_editor-core/src/t2b/reader.rs
+++ b/ievr_cfg_bin_editor-core/src/t2b/reader.rs
@@ -71,10 +71,12 @@ impl T2b {
 
         // println!("{:?}", entry_section);
 
-        Some(T2b::create_configuration(entry_section, checksum_section, &value_string_data, checksum_string_data, encoding, hash_type))
+        Some(T2b::create_configuration(entry_section, checksum_section, &value_string_data, checksum_string_data, encoding, hash_type, file.len()))
     }
 
-    fn create_configuration(entry_section: T2bEntrySection, checksum_section: T2bChecksumSection, value_string_data: &[u8], checksum_string_data: &[u8], encoding: i16, hash_type: HashType) -> T2b {
+    fn create_configuration(entry_section: T2bEntrySection, checksum_section: T2bChecksumSection, value_string_data: &[u8], 
+        checksum_string_data: &[u8], encoding: i16, hash_type: HashType, file_size: usize
+    ) -> T2b {
         let checksum_offset_lookup: HashMap<u32, u32> = checksum_section.checksum_entries.iter().map(|section| {
             (section.crc, section.string_offset - checksum_section.checksum_entries[0].string_offset)
         })
@@ -128,6 +130,7 @@ impl T2b {
         }
 
         T2b {
+            file_size,
             entries: config_entries,
             encoding,
             value_length: entry_section.value_length,

--- a/ievr_cfg_bin_editor-core/src/t2b/writer.rs
+++ b/ievr_cfg_bin_editor-core/src/t2b/writer.rs
@@ -7,12 +7,12 @@ use super::{
 };
 
 impl T2b {
-    pub fn write(t2b: T2b) {
+    pub fn write(self, output_file: &mut File) -> Result<(), std::io::Error> {
         let mut bw = BinaryWriter::default();
 
         bw.set_position(0x10);
 
-        let entry_header = write_entries(&mut bw, &t2b);
+        let entry_header = write_entries(&mut bw, &self);
 
         bw.set_position(0);
         write_header(&mut bw, &entry_header);
@@ -20,16 +20,15 @@ impl T2b {
         let checksum_partition_offset = (entry_header.string_data_offset + entry_header.string_data_length + 0xF) & !0xF;
 
         bw.set_position(checksum_partition_offset as usize + 0x10);
-        let checksum_header = write_checksum_entries(&mut bw, &t2b);
+        let checksum_header = write_checksum_entries(&mut bw, &self);
 
         bw.set_position(checksum_partition_offset as usize);
         write_checksum_header(&mut bw, &checksum_header);
 
         bw.set_position((checksum_partition_offset + checksum_header._size) as usize);
-        write_footer(&mut bw, t2b.encoding);
+        write_footer(&mut bw, self.encoding);
 
-        let mut file = File::create("output").unwrap();
-        file.write_all(bw.get_data()).unwrap();
+        output_file.write_all(bw.get_data())
     }
 }
 
@@ -102,7 +101,7 @@ fn write_entry(bw: &mut BinaryWriter, entry: &T2bEntry, encoding: i16, hash_type
     for value in &entry.values {
         match value.r#type {
             T2bValueType::String => write_string(bw, 
-                if let T2bValue::String(s) = &value.value { s.to_string() } else { panic!() },
+                if let T2bValue::String(s) = &value.value { s } else { panic!() },
                  encoding, value_length, string_offset_base, written_strings, string_offset, string_count),
 
             T2bValueType::Integer => match value_length {
@@ -120,8 +119,8 @@ fn write_entry(bw: &mut BinaryWriter, entry: &T2bEntry, encoding: i16, hash_type
     }
 }
 
-fn write_string(bw: &mut BinaryWriter, string: String, encoding: i16, value_length: ValueLength, string_offset_base: u32, written_strings: &mut HashMap<String, i64>, string_offset: &mut u32, string_count: &mut u32) {
-    if let Some(name_offset) = written_strings.get(&string) {
+fn write_string(bw: &mut BinaryWriter, string: &str, encoding: i16, value_length: ValueLength, string_offset_base: u32, written_strings: &mut HashMap<String, i64>, string_offset: &mut u32, string_count: &mut u32) {
+    if let Some(name_offset) = written_strings.get(string) {
         write_value(bw, name_offset - string_offset_base as i64, value_length);
         return
     }
@@ -149,20 +148,24 @@ fn write_value(bw: &mut BinaryWriter, value: i64, value_length: ValueLength) {
     }
 }
 
-fn cache_strings(mut position: i64, value: &str, encoding: i16, written_strings: &mut HashMap<String, i64>) {
+fn cache_strings(mut position: i64, value: &str, _encoding: i16, written_strings: &mut HashMap<String, i64>) {
     for (offset, ch) in value.char_indices() {
         // Create a slice from the current offset to the end
         let suffix = &value[offset..];
         
         // Only allocate the String (heap) when inserting into the Map
-        written_strings.entry(suffix.to_string()).or_insert(position);
+        if !written_strings.contains_key(suffix) {
+            written_strings.insert(suffix.to_owned(), position);
+        }
 
         // Update position
         position += ch.len_utf8() as i64;
     }
 
     // Cache the final empty string
-    written_strings.entry(String::new()).or_insert(position);
+    if !written_strings.contains_key("") {
+        written_strings.insert("".to_owned(), position);
+    }
 }
 
 fn write_header(bw: &mut BinaryWriter, header: &T2bEntryHeader) {
@@ -175,10 +178,10 @@ fn write_header(bw: &mut BinaryWriter, header: &T2bEntryHeader) {
 fn write_checksum_entries(bw: &mut BinaryWriter, t2b: &T2b) -> T2bChecksumHeader {
     let mut seen = HashSet::new();
 
-    let names: Vec<String> = t2b.entries
+    let names: Vec<&str> = t2b.entries
         .iter()
-        .map(|e| e.name.clone())
-        .filter(|name| seen.insert(name.clone()))
+        .map(|e| e.name.as_str())
+        .filter(|&name| seen.insert(name))
         .collect();
 
     let header_string_offset = ((0x10 + names.len() * 8 + 0xF) & !0xF) as u32;

--- a/ievr_cfg_bin_editor-core/src/t2b/writer.rs
+++ b/ievr_cfg_bin_editor-core/src/t2b/writer.rs
@@ -1,4 +1,6 @@
-use std::{collections::{HashMap, HashSet}, fs::File, io::Write};
+use std::{collections::{HashSet, hash_map::Entry}, fs::File, io::Write};
+
+use rustc_hash::FxHashMap;
 
 use crate::{common::{binary_writer::BinaryWriter, compute_crc32_jam, compute_crc32_standard}, t2b::{HashType, T2bEntry, T2bValue, T2bValueType, ValueLength, checksum_section::T2bChecksumHeader, entry_section::T2bEntryHeader}};
 
@@ -8,7 +10,7 @@ use super::{
 
 impl T2b {
     pub fn write(self, output_file: &mut File) -> Result<(), std::io::Error> {
-        let mut bw = BinaryWriter::default();
+        let mut bw = BinaryWriter::new(self.file_size);
 
         bw.set_position(0x10);
 
@@ -45,7 +47,7 @@ fn write_entries(bw: &mut BinaryWriter, t2b: &T2b) -> T2bEntryHeader {
     let mut string_offset= bw.get_position() as u32 + string_data_offset - 0x10;
     let string_offset_base = string_offset;
     
-    let mut written_strings: HashMap<String, i64> = HashMap::new();
+    let mut written_strings: FxHashMap<&str, i64> = FxHashMap::with_hasher(Default::default());
     let mut string_count = 0u32;
 
     for entry in &t2b.entries {
@@ -69,8 +71,8 @@ fn write_entries(bw: &mut BinaryWriter, t2b: &T2b) -> T2bEntryHeader {
     }
 }
 
-fn write_entry(bw: &mut BinaryWriter, entry: &T2bEntry, encoding: i16, hash_type: HashType, 
-    value_length: ValueLength, string_offset_base: u32, written_strings: &mut HashMap<String, i64>, 
+fn write_entry<'a>(bw: &mut BinaryWriter, entry: &'a T2bEntry, encoding: i16, hash_type: HashType, 
+    value_length: ValueLength, string_offset_base: u32, written_strings: &mut FxHashMap<&'a str, i64>, 
     string_offset: &mut u32, string_count: &mut u32) 
 {
     match hash_type {
@@ -119,7 +121,7 @@ fn write_entry(bw: &mut BinaryWriter, entry: &T2bEntry, encoding: i16, hash_type
     }
 }
 
-fn write_string(bw: &mut BinaryWriter, string: &str, encoding: i16, value_length: ValueLength, string_offset_base: u32, written_strings: &mut HashMap<String, i64>, string_offset: &mut u32, string_count: &mut u32) {
+fn write_string<'a>(bw: &mut BinaryWriter, string: &'a str, encoding: i16, value_length: ValueLength, string_offset_base: u32, written_strings: &mut FxHashMap<&'a str, i64>, string_offset: &mut u32, string_count: &mut u32) {
     if let Some(name_offset) = written_strings.get(string) {
         write_value(bw, name_offset - string_offset_base as i64, value_length);
         return
@@ -148,16 +150,16 @@ fn write_value(bw: &mut BinaryWriter, value: i64, value_length: ValueLength) {
     }
 }
 
-fn cache_strings(mut position: i64, value: &str, _encoding: i16, written_strings: &mut HashMap<String, i64>) {
+fn cache_strings<'a>(mut position: i64, value: &'a str, _encoding: i16, written_strings: &mut FxHashMap<&'a str, i64>) {
     for (offset, ch) in value.char_indices() {
         // Create a slice from the current offset to the end
         let suffix = &value[offset..];
         
         // Only allocate the String (heap) when inserting into the Map
-        if written_strings.contains_key(suffix) { // This means that every following suffix is also in the hashmap
-            break; 
+        match written_strings.entry(suffix) {
+            Entry::Occupied(_) => break,
+            Entry::Vacant(v) => { v.insert(position); }
         }
-        written_strings.insert(suffix.to_owned(), position);
 
         // Update position
         position += ch.len_utf8() as i64;
@@ -165,7 +167,7 @@ fn cache_strings(mut position: i64, value: &str, _encoding: i16, written_strings
 
     // Cache the final empty string
     if !written_strings.contains_key("") {
-        written_strings.insert("".to_owned(), position);
+        written_strings.insert("", position);
     }
 }
 
@@ -189,7 +191,7 @@ fn write_checksum_entries(bw: &mut BinaryWriter, t2b: &T2b) -> T2bChecksumHeader
 
     let mut string_offset = (bw.get_position() as u32 + header_string_offset - 0x10) as u32;
     let string_offset_base = string_offset;
-    let mut written_strings = HashMap::new();
+    let mut written_strings = FxHashMap::with_hasher(Default::default());
     let mut string_count = 0;
 
     for name in names {

--- a/ievr_cfg_bin_editor-core/src/t2b/writer.rs
+++ b/ievr_cfg_bin_editor-core/src/t2b/writer.rs
@@ -131,7 +131,7 @@ fn write_string(bw: &mut BinaryWriter, string: &str, encoding: i16, value_length
     let entry_offset = bw.get_position();
 
     bw.set_position(*string_offset as usize);
-    cache_strings(*string_offset as i64, &string, encoding, written_strings);
+    cache_strings(*string_offset as i64, string, encoding, written_strings);
     
     bw.write_string(&string, true);
 
@@ -154,9 +154,10 @@ fn cache_strings(mut position: i64, value: &str, _encoding: i16, written_strings
         let suffix = &value[offset..];
         
         // Only allocate the String (heap) when inserting into the Map
-        if !written_strings.contains_key(suffix) {
-            written_strings.insert(suffix.to_owned(), position);
+        if written_strings.contains_key(suffix) { // This means that every following suffix is also in the hashmap
+            break; 
         }
+        written_strings.insert(suffix.to_owned(), position);
 
         // Update position
         position += ch.len_utf8() as i64;


### PR DESCRIPTION
Closes #9 : This PR improves performance by over 2x, by limiting the number of allocation of strings and using a less safe hashing algorithm, which for our purpose doesn't matter since it's internal. I also improved the `write` API of database by providing a method on the object directly.